### PR TITLE
Sync with changes in miking repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 run:
 	cd tool/main && \
-	mi main.mc -- \
+	boot main.mc -- \
 	--benchmarks ../../benchmark-suite/benchmarks \
 	--runtimes ../../benchmark-suite/runtimes \
 	--iters 5 \
@@ -11,10 +11,10 @@ run:
 
 plot:
 	cd tool/main && \
-	mi main.mc -- \
+	boot main.mc -- \
 	--benchmarks ../../benchmark-suite/benchmarks \
 	--plot ../../results.toml \
 	&& convert *.png ../../report.pdf
 
 test:
-	cd tool/tool ; mi test .
+	cd tool/tool ; boot --test .

--- a/benchmark-suite/benchmarks/tsp/mcore/tabu-search/tabu-search.mc
+++ b/benchmark-suite/benchmarks/tsp/mcore/tabu-search/tabu-search.mc
@@ -1,4 +1,5 @@
 include "../tsp.mc"
+include "eqset.mc"
 
 mexpr
 
@@ -22,7 +23,7 @@ let randomBest = lam ns. lam state.
 in
 
 let toursEq = lam t1. lam t2.
-  setEqual (digraphEdgeEq g) t1 t2 in
+  eqsetEqual (digraphEdgeEq g) t1 t2 in
 
 let metaTabu = (TabuSearch {tabu = [initTour],
                             isTabu = lam tour. lam tabu. any (toursEq tour) tabu,

--- a/benchmark-suite/benchmarks/tsp/mcore/tsp.mc
+++ b/benchmark-suite/benchmarks/tsp/mcore/tsp.mc
@@ -2,6 +2,7 @@
 
 include "local-search.mc"
 include "string.mc"
+include "eqset.mc"
 
 -- "[a, b, c]" -> [a, b, c]
 let parseVertices = lam str.
@@ -69,7 +70,7 @@ let neighbours = lam g. lam state.
 
   let neighbourFromExchange = lam oldEdgs. lam newEdgs. lam tour.
     let equal = digraphEdgeEq g in
-    setUnion equal newEdgs (setDiff equal tour oldEdgs)
+    eqsetUnion equal newEdgs (eqsetDiff equal tour oldEdgs)
   in
 
   let possibleExchanges =

--- a/benchmark-suite/runtimes/mcore2ocaml.toml
+++ b/benchmark-suite/runtimes/mcore2ocaml.toml
@@ -1,7 +1,7 @@
 provides = "MCore2OCaml"
 
 [[command]]
-required_executables = ["boot.mi", "rm"]
-build_command = "boot.mi /Users/lingmar/Dropbox/PhD/Research/miking-lang/miking/stdlib/../src/main/mi.mc -- compile {argument}.mc"
+required_executables = ["mi", "rm"]
+build_command = "mi compile {argument}.mc"
 command = "./{argument}"
 clean_command = "rm {argument}"

--- a/tool/main/main.mc
+++ b/tool/main/main.mc
@@ -3,6 +3,7 @@ include "../tool/runner.mc"
 include "../tool/path.mc"
 include "../tool/post-process.mc"
 include "string.mc"
+include "common.mc"
 
 let menu = strJoin "\n"
 [ "Usage: mi main -- <options>"

--- a/tool/tool/config-scanner.mc
+++ b/tool/tool/config-scanner.mc
@@ -5,7 +5,7 @@ include "map.mc"
 include "path.mc"
 include "bool.mc"
 include "utils.mc"
-include "set.mc"
+include "eqset.mc"
 
 type Timing
 -- Don't measure the time
@@ -145,7 +145,7 @@ let findBenchmarks = -- ... -> {benchmarks : [Benchmark], datasets : Map String 
   lam runtimes : Map String Runtime.
 
   let addData = lam pb : PartialBench. lam dataStr : String.
-    {pb with data = setUnion eqString  pb.data dataStr} in
+    {pb with data = eqsetUnion eqString  pb.data dataStr} in
 
   -- Update a partial benchmark 'b' with information from 'configFile'.
   let updatePartialBench =

--- a/tool/tool/plot.mc
+++ b/tool/tool/plot.mc
@@ -1,3 +1,4 @@
+include "option.mc"
 
 type PlotOptions =
 { legend : Bool
@@ -49,7 +50,7 @@ let _markerClear = lam. modref _markerIdx 0
 let plotDefaultOptions =
 { legend = true
 , grid = true
-, xmin = Some 0
+, xmin = Some 0.0
 , xmax = None () -- Let Python set the max value
 , ymin = Some 0.0
 , ymax = None ()

--- a/tool/tool/runner.mc
+++ b/tool/tool/runner.mc
@@ -1,7 +1,8 @@
-include "ocaml/process-helpers.mc"
+include "ocaml/sys.mc"
 include "path.mc"
 include "config-scanner.mc"
 include "utils.mc"
+include "common.mc"
 
 type Result = { benchmark : Benchmark
               , data : Data
@@ -27,7 +28,7 @@ let insertArg = lam cmd. lam arg.
 let runCommand : String -> String -> Path -> (ExecResult, Float) =
   lam cmd. lam stdin. lam cwd.
     let t1 = wallTimeMs () in
-    let r = phRunCommand (strSplit " " cmd) stdin cwd in
+    let r = sysRunCommand (strSplit " " cmd) stdin cwd in
     let t2 = wallTimeMs () in
     (r, subf t2 t1)
 

--- a/tool/tool/runner.mc
+++ b/tool/tool/runner.mc
@@ -27,8 +27,11 @@ let insertArg = lam cmd. lam arg.
 -- result and the elapsed time in ms.
 let runCommand : String -> String -> Path -> (ExecResult, Float) =
   lam cmd. lam stdin. lam cwd.
+    let stdin = join ["\"", escapeString stdin, "\""] in
+    let cmd = (strSplit " " cmd) in
+
     let t1 = wallTimeMs () in
-    let r = sysRunCommand (strSplit " " cmd) stdin cwd in
+    let r = sysRunCommand cmd stdin cwd in
     let t2 = wallTimeMs () in
     (r, subf t2 t1)
 


### PR DESCRIPTION
What the title says.

The latest results are attached. Note that we beat the ocaml compiler on `fibonacci` but that we are still behind on `bstree`.

[report.pdf](https://github.com/miking-lang/miking-benchmarks/files/6363861/report.pdf)
