### PR TITLE
Updates for `midppl/*.mc`

### DIFF
--- a/benchmark-suite/benchmarks/ppl/midppl/crbd.mc
+++ b/benchmark-suite/benchmarks/ppl/midppl/crbd.mc
@@ -37,7 +37,14 @@ recursive
     lam mu: Float.
     lam rho: Float.
       let duration = assume (Exponential mu) in
-      if and (gtf duration startTime) (eqBool (assume (Bernoulli rho)) true) then
+      let cond =
+        -- `and` does not use short-circuiting: using `if` as below is more
+        -- efficient
+        if (gtf duration startTime) then
+          (eqBool (assume (Bernoulli rho)) true)
+        else false
+      in
+      if cond then
         false
       else
         let branchLength = if ltf duration startTime then duration else startTime in

--- a/benchmark-suite/benchmarks/ppl/midppl/crbd.mc
+++ b/benchmark-suite/benchmarks/ppl/midppl/crbd.mc
@@ -81,6 +81,7 @@ let simTree: Tree -> Tree -> Float -> Float -> Float -> () =
     let lnProb3 = simBranch n startTime stopTime lambda mu rho in
 
     weight (addf lnProb1 (addf lnProb2 lnProb3));
+    resample;
 
     match tree with Node { left = left, right = right } then
       simTree left tree lambda mu rho;
@@ -97,6 +98,7 @@ let numLeaves = countLeaves tree in
 let corrFactor =
   subf (mulf (subf (int2float numLeaves) 1.) (log 2.)) (lnFactorial numLeaves) in
 weight corrFactor;
+resample;
 
 -- Start of the simulation along the two branches
 (match tree with Node { left = left, right = right } then

--- a/benchmark-suite/benchmarks/ppl/midppl/pplprelude.mc
+++ b/benchmark-suite/benchmarks/ppl/midppl/pplprelude.mc
@@ -7,7 +7,6 @@ include "math.mc"
 -- The CorePPL to RootPPL compiler should translate this
 -- to the correct functions.
 let log: Float -> Float = lam x: Float. x
-let int2float: Int -> Float = lam x: Int. (x; 1.0)
 
 -- Other functions that might need special treatment are:
 --  'and', 'inf',

--- a/benchmark-suite/benchmarks/ppl/midppl/pplprelude.mc
+++ b/benchmark-suite/benchmarks/ppl/midppl/pplprelude.mc
@@ -2,15 +2,6 @@
 include "bool.mc"
 include "math.mc"
 
-
--- These function are right now placeholders.
--- The CorePPL to RootPPL compiler should translate this
--- to the correct functions.
-let log: Float -> Float = lam x: Float. x
-
--- Other functions that might need special treatment are:
---  'and', 'inf',
-
 -- Help function that is needed in models
 recursive
 let lnFactorial: Int -> Float = lam n: Int.

--- a/benchmark-suite/benchmarks/ppl/midppl/pplprelude.mc
+++ b/benchmark-suite/benchmarks/ppl/midppl/pplprelude.mc
@@ -7,7 +7,7 @@ include "math.mc"
 -- The CorePPL to RootPPL compiler should translate this
 -- to the correct functions.
 let log: Float -> Float = lam x: Float. x
-let int2float: Int -> Float = lam. 1.0
+let int2float: Int -> Float = lam x: Int. (x; 1.0)
 
 -- Other functions that might need special treatment are:
 --  'and', 'inf',

--- a/benchmark-suite/benchmarks/ppl/midppl/tree.mc
+++ b/benchmark-suite/benchmarks/ppl/midppl/tree.mc
@@ -10,17 +10,13 @@ let getAge = lam n: Tree. match n with Node r then r.age else
                  match n with Leaf r then r.age else
                  never
 
--- Project the left or right child tree, assuming that it is of a node type
-let getLeft = lam t. match t with Node r then r.left else error "Not a node"
-let getRight = lam t. match t with Node r then r.right else error "Not a node"
-
 
 -- Count the number of leaves in a tree
 recursive
-let countLeaves = lam tree.
+let countLeaves: Tree -> Int = lam tree: Tree.
   match tree with Node r then
-    addf (countLeaves r.left) (countLeaves r.right)
-  else 1.
+    addi (countLeaves r.left) (countLeaves r.right)
+  else 1
 end
 
 


### PR DESCRIPTION
- Add full type annotations to functions and fix some other type errors.
- Replace `and` with short-circuit.
- Remove `getLeft` and `getRight`, replace with direct pattern match.
- Add `resample`.
- Remove `log` (now external) and `int2float` (now intrinsic).
