### PR TITLE
Changed stack size to reflect new rootppl optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+number_iterations=15
+number_warmups=1
+prefix=A
+
 .PHONY: run plot test
 
 run:
@@ -44,9 +48,10 @@ run-experiment-CRBD:
 	boot eval tool/main/main.mc -- \
 	  --benchmarks benchmark-suite/benchmarks/ppl \
 	  --runtimes benchmark-suite/runtimes \
-	  --iters 100 \
+	  --iters $(number_iterations) \
 	  --output toml \
-	  --warmups 1
+	  --warmups $(number_warmups)
+	cp output.toml output-$(prefix)-$(number_iterations)-experiment-CRBD.toml
 	rm benchmark-suite/benchmarks/ppl/birch/experiment-CRBD.toml benchmark-suite/benchmarks/ppl/midppl/experiment-CRBD.toml benchmark-suite/benchmarks/ppl/pyro+numba/experiment-CRBD.toml benchmark-suite/benchmarks/ppl/pyro+numpy/experiment-CRBD.toml benchmark-suite/benchmarks/ppl/rootppl/experiment-CRBD.toml benchmark-suite/benchmarks/ppl/webppl/experiment-CRBD.toml
 
 
@@ -54,10 +59,14 @@ run-experiment-OptimizedCRBD:
 	cp benchmark-suite/benchmarks/ppl/birch/experiment-OptimizedCRBD.toml.skip benchmark-suite/benchmarks/ppl/birch/experiment-OptimizedCRBD.toml
 	cp benchmark-suite/benchmarks/ppl/rootppl/experiment-OptimizedCRBD.toml.skip benchmark-suite/benchmarks/ppl/rootppl/experiment-OptimizedCRBD.toml
 	cp benchmark-suite/benchmarks/ppl/pyro+numba/experiment-OptimizedCRBD.toml.skip benchmark-suite/benchmarks/ppl/pyro+numba/experiment-OptimizedCRBD.toml
-	boot eval tool/main/main.mc -- \
+	boot eval tool/main/main.mc  -- \
 	  --benchmarks benchmark-suite/benchmarks/ppl \
 	  --runtimes benchmark-suite/runtimes \
-	  --iters 100 \
+	  --iters $(number_iterations) \
 	  --output toml \
-	  --warmups 1
+	  --warmups $(number_warmups)	
+	cp output.toml output-$(prefix)-$(number_iterations)-experiment-OptimizedCRBD.toml
 	rm benchmark-suite/benchmarks/ppl/birch/experiment-OptimizedCRBD.toml benchmark-suite/benchmarks/ppl/rootppl/experiment-OptimizedCRBD.toml benchmark-suite/benchmarks/ppl/pyro+numba/experiment-OptimizedCRBD.toml
+
+clean:
+	rm output.toml

--- a/benchmark-suite/benchmarks/ppl/midppl/example.toml.skip
+++ b/benchmark-suite/benchmarks/ppl/midppl/example.toml.skip
@@ -2,7 +2,7 @@
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "-j 32 --stack_size 100000"
+buildOptions = "-j 32 --stack_size 1000"
 options = "8192"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"

--- a/benchmark-suite/benchmarks/ppl/midppl/experiment-CRBD.toml.skip
+++ b/benchmark-suite/benchmarks/ppl/midppl/experiment-CRBD.toml.skip
@@ -1,8 +1,7 @@
-
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "-j 32 --stack_size 100000"
+buildOptions = "-j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "8192"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
@@ -10,15 +9,25 @@ cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "--omp -j 32 --stack_size 100000"
+buildOptions = "--arch 75 -j 32 --stack_size 1000 --ess_threshold 1.0"
+options = "8192"
+buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
+cleanExtra = "rm -f tree-instance.mc; rootppl clean"
+  
+[[app]]
+runtime = "CorePPL"
+argument = "crbd.mc"
+buildOptions = "--omp -j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "8192"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 
+  
+  
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "-j 32 --stack_size 100000"
+buildOptions = "-j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "16384"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
@@ -26,15 +35,25 @@ cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "--omp -j 32 --stack_size 100000"
+buildOptions = "--arch 75 -j 32 --stack_size 1000 --ess_threshold 1.0"
+options = "16384"
+buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
+cleanExtra = "rm -f tree-instance.mc; rootppl clean"
+  
+[[app]]
+runtime = "CorePPL"
+argument = "crbd.mc"
+buildOptions = "--omp -j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "16384"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 
+  
+  
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "-j 32 --stack_size 100000"
+buildOptions = "-j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "32768"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
@@ -42,7 +61,7 @@ cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "--omp -j 32 --stack_size 100000"
+buildOptions = "--arch 75 -j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "32768"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
@@ -50,7 +69,17 @@ cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "-j 32 --stack_size 100000"
+buildOptions = "--omp -j 32 --stack_size 1000 --ess_threshold 1.0"
+options = "32768"
+buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
+cleanExtra = "rm -f tree-instance.mc; rootppl clean"
+
+  
+  
+[[app]]
+runtime = "CorePPL"
+argument = "crbd.mc"
+buildOptions = "-j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "65536"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
@@ -58,15 +87,25 @@ cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "--omp -j 32 --stack_size 100000"
+buildOptions = "--arch 75 -j 32 --stack_size 1000 --ess_threshold 1.0"
+options = "65536"
+buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
+cleanExtra = "rm -f tree-instance.mc; rootppl clean"
+  
+[[app]]
+runtime = "CorePPL"
+argument = "crbd.mc"
+buildOptions = "--omp -j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "65536"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 
+
+  
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "-j 32 --stack_size 100000"
+buildOptions = "-j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "131072"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
@@ -74,15 +113,25 @@ cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "--omp -j 32 --stack_size 100000"
+buildOptions = "--arch 75 -j 32 --stack_size 1000 --ess_threshold 1.0"
+options = "131072"
+buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
+cleanExtra = "rm -f tree-instance.mc; rootppl clean"
+  
+[[app]]
+runtime = "CorePPL"
+argument = "crbd.mc"
+buildOptions = "--omp -j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "131072"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 
+
+  
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "-j 32 --stack_size 100000"
+buildOptions = "-j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "262144"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
@@ -90,10 +139,19 @@ cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 [[app]]
 runtime = "CorePPL"
 argument = "crbd.mc"
-buildOptions = "--omp -j 32 --stack_size 100000"
+buildOptions = "--arch 75 -j 32 --stack_size 1000 --ess_threshold 1.0"
+options = "262144"
+buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
+cleanExtra = "rm -f tree-instance.mc; rootppl clean"
+  
+[[app]]
+runtime = "CorePPL"
+argument = "crbd.mc"
+buildOptions = "--omp -j 32 --stack_size 1000 --ess_threshold 1.0"
 options = "262144"
 buildExtra = "node ../tree-utils/midppl-tree-parser.js ../input-data/Alcedinidae.phyjson  0.5684210526315789 > tree-instance.mc"
 cleanExtra = "rm -f tree-instance.mc; rootppl clean"
 
+  
 [[post]]
 runtime = "id"


### PR DESCRIPTION
This is a very small urgent PR.

1. I changed the stack size settings in the TOML files to reflect the new stack size optimizations.
2. Optimized the Makefile: now you can indicate the number of iterations as a parameter up front, instead of tweaking inside the long commands.