### PR TITLE
Revert change in `types.mc` to make tests pass

### DIFF
--- a/tool/tool/types.mc
+++ b/tool/tool/types.mc
@@ -357,7 +357,8 @@ utest
             options = [ {name = "tag", contents = "tag-post-1"},
                         {name = "argument", contents = "post"}],
             cwd = "path/to/post-1" }],
-  input = []
+  input = [],
+  warnings = []
 }
 
 utest

--- a/tool/tool/types.mc
+++ b/tool/tool/types.mc
@@ -242,7 +242,12 @@ let appFromToml : Path -> TomlTable -> App =
       case (None (), None ()) then cwd
       end
     in
-    let cwdApp = pathAbs cwdApp in
+
+    -- TODO(dlunde,2022-11-23): The below is useful to clean up paths (leading
+    -- to, e.g., nicer log output). However, it breaks some of the utests in
+    -- this file.
+    -- let cwdApp = pathAbs cwdApp in
+
     -- Remove all key-values that we have already taken care of
     let m = mapRemove "cwd" m in
     let m = mapRemove "runtime" m in


### PR DESCRIPTION
https://github.com/miking-lang/miking-benchmarks/commit/fbeefaa1d85d5e35c4afb6cf48c8cc52a478075e added an application of `pathAbs` in `types.mc` to clean up logging output, but as it turns out this doesn't combine well with the current `utest`s in `types.mc`. I reverted the change for now, until we have time to update the `utest`s.